### PR TITLE
bump dependency - marked to 0.3.3, there are 2 security issues in 0.3.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "gravatar": "^1.0.6",
     "hapi": "^6.0.2",
     "jade": "^1.3.1",
-    "marked": "^0.3.2",
+    "marked": "^0.3.3",
     "semi-static": "0.0.5",
     "sugar": "^1.4.1",
     "underscore": "^1.6.0",


### PR DESCRIPTION
https://nodesecurity.io/advisories/marked_redos
https://nodesecurity.io/advisories/marked_vbscript_injection